### PR TITLE
Adding query support

### DIFF
--- a/src/record/index.ts
+++ b/src/record/index.ts
@@ -8,11 +8,20 @@ export class Record {
 
   public list(path: string): DeepstreamListObservable<DeepstreamRecordObservable<any>[]> {
     let list = this.client.record.getList(path);
+    let isQuery = path.indexOf('search?') !== -1;
+    let listName;
+
+    if (isQuery) {
+      let queryString = path.split('search?')[1];
+      let parsed = JSON.parse(queryString);
+      listName = parsed.table;
+    }
     
     let observable = DeepstreamListObservable.create((obs: Observer<DeepstreamRecordObservable<any>[]>) => {
       list.subscribe((paths) => {
         let records = paths.map((path) => {
-          return this.record(path);
+          let recordPath = isQuery ? `${listName}/${path}` : path;
+          return this.record(recordPath);
         });
         
         obs.next(records);


### PR DESCRIPTION
Querying and lists use the same method in deepstream, but have differing results (lists return the full record name, e.g. list/item1, while queries only the item name, e.g. item1).

To make the lib work with both of them I've made a few changes.